### PR TITLE
Allow copying job logs to the invoking job

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -92,6 +92,7 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         wait-for-completion-interval: 10s
         wait-for-completion-timeout: 5m
+        repost-logs: true
       continue-on-error: true
     - uses: nick-invision/assert-action@v1
       with:
@@ -122,6 +123,7 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         wait-for-completion-interval: 10s
         wait-for-completion-timeout: 5m
+        repost-logs: true
       continue-on-error: true
     - run: echo "worflow-conclusion=${{ steps.failing-workflow.outputs.workflow-conclusion }}"
     - uses: nick-invision/assert-action@v1
@@ -153,6 +155,7 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         wait-for-completion-interval: 10s
         wait-for-completion-timeout: 30s
+        repost-logs: true
       continue-on-error: true
     - uses: nick-invision/assert-action@v1
       with:
@@ -186,4 +189,3 @@ jobs:
       uses: mikeal/publish-to-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/long-running.yml
+++ b/.github/workflows/long-running.yml
@@ -9,3 +9,9 @@ jobs:
     steps:
       - name: Sleep
         run: sleep 10s
+  
+  additional_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: echo "Extra job completed!"

--- a/action.yaml
+++ b/action.yaml
@@ -41,6 +41,10 @@ inputs:
     description: 'Time to wait (+unit) between two polls to get run status'
     required: false
     default: 1m
+  repost-logs:
+    description: 'Whether to post the logs of the triggered run back into the original job'
+    required: false
+    default: false
 
 runs:
   using: 'node12'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,8 @@ export function getArgs() {
   const waitForCompletion = waitForCompletionStr && waitForCompletionStr === 'true';
   const waitForCompletionTimeout = toMilliseconds(core.getInput('wait-for-completion-timeout'));
   const checkStatusInterval = toMilliseconds(core.getInput('wait-for-completion-interval'));
+  const repostLogsStr = core.getInput('repost-logs');
+  const repostLogs = repostLogsStr && repostLogsStr === 'true';
 
   return {
     token,
@@ -56,7 +58,8 @@ export function getArgs() {
     displayWorkflowUrlInterval,
     checkStatusInterval,
     waitForCompletion,
-    waitForCompletionTimeout
+    waitForCompletionTimeout,
+    repostLogs
   };
 }
 


### PR DESCRIPTION
This adds a new `repost-logs` parameter, which, if `true`, and `wait-for-completion-*` is also set, causes the action to download the logs of all jobs in the action and output them in the invoking action.

The use case for this is to repost the outputs of workflows that run in private repositories, but that are triggered from a public repo, so that the workflow results are visible to contributors. Specifically I have a setup like this to run a self-hosted [GitHub Actions runner](https://github.com/actions/runner) on the private repo, so that not everyone can execute arbitrary code on it, but I still want contributors to be able to see the workflow results from the self-hosted runner.