### PR TITLE
Fix bug with milliseconds precision

### DIFF
--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -135,7 +135,7 @@ export class WorkflowHandler {
       debug('List Workflow Runs', response);
 
       const runs = response.data.workflow_runs
-        .filter((r: any) => new Date(r.created_at).valueOf() >= this.triggerDate);
+        .filter((r: any) => new Date(r.created_at).setMilliseconds(0) >= this.triggerDate);
       debug(`Filtered Workflow Runs (after trigger date: ${new Date(this.triggerDate).toISOString()})`, runs.map((r: any) => ({
         id: r.id,
         name: r.name,


### PR DESCRIPTION
Workflow runs that GitHub API returns don't have millisecond precision.
So there might be a situation that the trigger date is:
`"2021-10-08T18:42:45.031Z"` while the corresponding run that GitHub API might return `created_at = "2021-10-08T18:42:45Z"` (if everything happened in less than a second).

That causes this action to fail by timeout (after trying to find run many times).

(There might be another solution where we use `date` header of GitHub response after create workflow dispatch)
