### PR TITLE
Provide run name optional parameter to fetch run id based on name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ All values must be strings (even if they are used as booleans or numbers in the 
 ### `repo`
 **Optional.** The default behavior is to trigger workflows in the same repo as the triggering workflow, if you wish to trigger in another GitHub repo "externally", then provide the owner + repo name with slash between them e.g. `microsoft/vscode`
 
+### `run-name`
+**Optional.** The default behavior is to get the remote run ID based on the latest workflow name and date, if you have multiple of the same workflow running at the same time it can point to an incorrect run id.
+You can specify the run name to fetch the run ID based on the actual run name.
+
 ### `wait-for-completion`
 **Optional.** If `true`, this action will actively poll the workflow run to get the result of the triggered workflow. It is enabled by default. If the triggered workflow fails due to either `failure`, `timed_out` or `cancelled` then the step that has triggered the other workflow will be marked as failed too.
 

--- a/action.yaml
+++ b/action.yaml
@@ -17,6 +17,9 @@ inputs:
   repo:
     description: 'Repo owner & name, slash separated, only set if invoking a workflow in a different repo'
     required: false
+  run-name:
+    description: 'If specified will select the run ID based on the run name'
+    required: false
   display-workflow-run-url:
     description: 'Get the URL of the triggered workflow and display it in logs (useful to follow the progress of the triggered workflow)'
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ function computeConclusion(start: number, waitForCompletionTimeout: number, resu
 async function run(): Promise<void> {
   try {
     const args = getArgs();
-    const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref);
+    const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.checkName);
 
     // Trigger workflow run
     await workflowHandler.triggerWorkflow(args.inputs);

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ function computeConclusion(start: number, waitForCompletionTimeout: number, resu
 async function run(): Promise<void> {
   try {
     const args = getArgs();
-    const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.checkName);
+    const workflowHandler = new WorkflowHandler(args.token, args.workflowRef, args.owner, args.repo, args.ref, args.runName);
 
     // Trigger workflow run
     await workflowHandler.triggerWorkflow(args.inputs);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,7 @@ export function getArgs() {
   const waitForCompletion = waitForCompletionStr && waitForCompletionStr === 'true';
   const waitForCompletionTimeout = toMilliseconds(core.getInput('wait-for-completion-timeout'));
   const checkStatusInterval = toMilliseconds(core.getInput('wait-for-completion-interval'));
+  const checkName = core.getInput('checkName')
 
   return {
     token,
@@ -56,7 +57,8 @@ export function getArgs() {
     displayWorkflowUrlInterval,
     checkStatusInterval,
     waitForCompletion,
-    waitForCompletionTimeout
+    waitForCompletionTimeout,
+    checkName
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export function getArgs() {
   const waitForCompletion = waitForCompletionStr && waitForCompletionStr === 'true';
   const waitForCompletionTimeout = toMilliseconds(core.getInput('wait-for-completion-timeout'));
   const checkStatusInterval = toMilliseconds(core.getInput('wait-for-completion-interval'));
-  const checkName = core.getInput('checkName')
+  const runName = core.getInput('run-name')
 
   return {
     token,
@@ -58,7 +58,7 @@ export function getArgs() {
     checkStatusInterval,
     waitForCompletion,
     waitForCompletionTimeout,
-    checkName
+    runName
   };
 }
 

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -52,7 +52,7 @@ export class WorkflowHandler {
               private owner: string,
               private repo: string,
               private ref: string,
-              private checkName: string) {
+              private runName: string) {
     // Get octokit client for making API calls
     this.octokit = github.getOctokit(token)
   }
@@ -126,45 +126,51 @@ export class WorkflowHandler {
     }
     try {
       core.debug('Get workflow run id');
-      const workflowId = await this.getWorkflowId();
-      const response = await this.octokit.actions.listWorkflowRuns({
-        owner: this.owner,
-        repo: this.repo,
-        workflow_id: workflowId,
-        event: 'workflow_dispatch'
-      });
-      debug('List Workflow Runs', response);
+      if (this.runName) {
 
-      const result = await this.octokit.rest.checks.listForRef({
-        check_name: this.checkName,
-        owner: this.owner,
-        repo: this.repo,
-        ref: this.ref,
-        filter: 'latest'
-      })
+        const result = await this.octokit.rest.checks.listForRef({
+          check_name: this.runName,
+          owner: this.owner,
+          repo: this.repo,
+          ref: this.ref,
+          filter: 'latest'
+        })
 
-      if (result.length == 0) {
-        throw new Error('Run not found');
+        if (result.length == 0) {
+          throw new Error('Run not found');
+        }
+
+        this.workflowRunId = result.check_runs[0].id as number;
+      }
+      else {
+        const workflowId = await this.getWorkflowId();
+
+        const response = await this.octokit.actions.listWorkflowRuns({
+          owner: this.owner,
+          repo: this.repo,
+          workflow_id: workflowId,
+          event: 'workflow_dispatch'
+        });
+
+        debug('List Workflow Runs', response);
+        const runs = response.data.workflow_runs
+            .filter((r: any) => new Date(r.created_at).setMilliseconds(0) >= this.triggerDate);
+        debug(`Filtered Workflow Runs (after trigger date: ${new Date(this.triggerDate).toISOString()})`, runs.map((r: any) => ({
+          id: r.id,
+          name: r.name,
+          created_at: r.creatd_at,
+          triggerDate: new Date(this.triggerDate).toISOString(),
+          created_at_ts: new Date(r.created_at).valueOf(),
+          triggerDateTs: this.triggerDate
+        })));
+
+        if (runs.length == 0) {
+          throw new Error('Run not found');
+        }
+
+        this.workflowRunId = runs[0].id as number;
       }
 
-      this.workflowRunId = result.check_runs[0].id as number;
-
-      // const runs = response.data.workflow_runs
-      //   .filter((r: any) => new Date(r.created_at).setMilliseconds(0) >= this.triggerDate);
-      // debug(`Filtered Workflow Runs (after trigger date: ${new Date(this.triggerDate).toISOString()})`, runs.map((r: any) => ({
-      //   id: r.id,
-      //   name: r.name,
-      //   created_at: r.creatd_at,
-      //   triggerDate: new Date(this.triggerDate).toISOString(),
-      //   created_at_ts: new Date(r.created_at).valueOf(),
-      //   triggerDateTs: this.triggerDate
-      // })));
-      //
-      // if (runs.length == 0) {
-      //   throw new Error('Run not found');
-      // }
-      //
-      // this.workflowRunId = runs[0].id as number;
       return this.workflowRunId;
     } catch (error) {
       debug('Get workflow run id error', error);

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -51,7 +51,8 @@ export class WorkflowHandler {
               private workflowRef: string,
               private owner: string,
               private repo: string,
-              private ref: string) {
+              private ref: string,
+              private checkName: string) {
     // Get octokit client for making API calls
     this.octokit = github.getOctokit(token)
   }
@@ -134,22 +135,36 @@ export class WorkflowHandler {
       });
       debug('List Workflow Runs', response);
 
-      const runs = response.data.workflow_runs
-        .filter((r: any) => new Date(r.created_at).setMilliseconds(0) >= this.triggerDate);
-      debug(`Filtered Workflow Runs (after trigger date: ${new Date(this.triggerDate).toISOString()})`, runs.map((r: any) => ({
-        id: r.id,
-        name: r.name,
-        created_at: r.creatd_at,
-        triggerDate: new Date(this.triggerDate).toISOString(),
-        created_at_ts: new Date(r.created_at).valueOf(),
-        triggerDateTs: this.triggerDate
-      })));
-  
-      if (runs.length == 0) {
+      const result = await this.octokit.rest.checks.listForRef({
+        check_name: this.checkName,
+        owner: this.owner,
+        repo: this.repo,
+        ref: this.ref,
+        filter: 'latest'
+      })
+
+      if (result.length == 0) {
         throw new Error('Run not found');
       }
 
-      this.workflowRunId = runs[0].id as number;
+      this.workflowRunId = result.check_runs[0].id as number;
+
+      // const runs = response.data.workflow_runs
+      //   .filter((r: any) => new Date(r.created_at).setMilliseconds(0) >= this.triggerDate);
+      // debug(`Filtered Workflow Runs (after trigger date: ${new Date(this.triggerDate).toISOString()})`, runs.map((r: any) => ({
+      //   id: r.id,
+      //   name: r.name,
+      //   created_at: r.creatd_at,
+      //   triggerDate: new Date(this.triggerDate).toISOString(),
+      //   created_at_ts: new Date(r.created_at).valueOf(),
+      //   triggerDateTs: this.triggerDate
+      // })));
+      //
+      // if (runs.length == 0) {
+      //   throw new Error('Run not found');
+      // }
+      //
+      // this.workflowRunId = runs[0].id as number;
       return this.workflowRunId;
     } catch (error) {
       debug('Get workflow run id error', error);


### PR DESCRIPTION
Hi!

First of all thank you for this Github action. We use it a lot to dispatch workflows, however we have ran into an issue.
We have a single repository in which all our actions run via dispatch. This works well most of the time, however when we run multiple of the same workflows at once in different repositories (it is templated so names are similar) sometimes the wrong workflow is attached to the wrong repository. This is due to the `run id` retrieval based on workflow name and date, which can have multiple entries. 

To fix this I propose to add an optional parameter `run-name` which can be used to obtain the `run id` based on the dispatched workflow name.

Hope it is straightforward, otherwise I am happy to elaborate more.
If this is unwanted we can ofcourse solve it internally, however I wanted to have an opportunity to merge it here.

Cheers 