### PR TITLE
bugfix: remove ms precision from `triggerDate`

### DIFF
--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -59,7 +59,7 @@ export class WorkflowHandler {
   async triggerWorkflow(inputs: any) {
     try {
       const workflowId = await this.getWorkflowId();
-      this.triggerDate = new Date(Date.now()).setMilliseconds(0);
+      this.triggerDate = new Date().setMilliseconds(0);
       const dispatchResp = await this.octokit.actions.createWorkflowDispatch({
         owner: this.owner,
         repo: this.repo,

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -59,7 +59,7 @@ export class WorkflowHandler {
   async triggerWorkflow(inputs: any) {
     try {
       const workflowId = await this.getWorkflowId();
-      this.triggerDate = Date.now();
+      this.triggerDate = new Date(Date.now()).setMilliseconds(0);
       const dispatchResp = await this.octokit.actions.createWorkflowDispatch({
         owner: this.owner,
         repo: this.repo,


### PR DESCRIPTION
remove millisecond precision from `triggerDate` which was the meaning of this previous bug fix https://github.com/aurelien-baudet/workflow-dispatch/pull/4.