### PR TITLE
fix(run-name): update class methods for WorkflowHandler

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3,6 +3,8 @@ name: Build & Test
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:
@@ -63,6 +65,27 @@ jobs:
         workflow: echo-2.yaml
         token: ${{ secrets.PERSONAL_TOKEN }}
         wait-for-completion: false
+
+  echo-3-test:
+    needs: [build]
+    runs-on: ubuntu-latest
+    name: "echo-3-test [trigger|by workflow filename|wait for completion by run-name]"
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+    - name: Download dist
+      uses: actions/download-artifact@v3
+      with:
+        name: build
+        path: dist
+    - name: Invoke echo 3 workflow using this action (wait for completion by run-name)
+      uses: ./
+      with:
+        workflow: echo-3.yaml
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        inputs: '{"message": "blah-blah"}'
+        wait-for-completion: true
+        run-name: echo-3-blah-blah
 
     # - name: Invoke echo 1 workflow by id
     #   uses: ./

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -227,9 +227,11 @@ jobs:
     #     ref: master 
 
   deploy:
+    if: ${{ github.event_name != 'pull_request' }}
     needs:
       - echo-1-test
       - echo-2-test
+      - echo-3-test
       - long-running-test
       - failing-test
       - timeout-test

--- a/.github/workflows/echo-3.yaml
+++ b/.github/workflows/echo-3.yaml
@@ -1,0 +1,20 @@
+name: Message Echo 3
+run-name: echo-3-${{ github.event.inputs.message }}
+
+on: 
+  workflow_dispatch:
+    inputs:
+      message:
+        description: "Message to echo"
+        required: true
+        # No default
+
+jobs:
+  echo:
+    runs-on: ubuntu-latest
+    environment:
+      name: foo
+      url: www.google.com
+    steps:
+      - name: Echo message
+        run: echo '${{ github.event.inputs.message }}'

--- a/dist/index.js
+++ b/dist/index.js
@@ -10045,39 +10045,17 @@ class WorkflowHandler {
     getWorkflowRunStatus() {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                const runId = yield this.getWorkflowRunId();
-                const response = yield this.octokit.rest.actions.getWorkflowRun({
-                    owner: this.owner,
-                    repo: this.repo,
-                    run_id: runId
-                });
-                (0, debug_1.debug)('Workflow Run status', response);
-                return {
-                    url: response.data.html_url,
-                    status: ofStatus(response.data.status),
-                    conclusion: ofConclusion(response.data.conclusion)
-                };
-            }
-            catch (error) {
-                (0, debug_1.debug)('Workflow Run status error', error);
-                throw error;
-            }
-        });
-    }
-    getWorkflowRunArtifacts() {
-        return __awaiter(this, void 0, void 0, function* () {
-            try {
                 if (this.runName) {
                     return yield this.findWorklowRunFromRunName(this.runName);
                 }
                 else {
                     const runId = yield this.getWorkflowRunId();
-                    const response = yield this.octokit.rest.actions.getWorkflowRunArtifacts({
+                    const response = yield this.octokit.rest.actions.getWorkflowRun({
                         owner: this.owner,
                         repo: this.repo,
                         run_id: runId
                     });
-                    (0, debug_1.debug)('Workflow Run artifacts', response);
+                    (0, debug_1.debug)('Workflow Run status', response);
                     return {
                         url: response.data.html_url,
                         status: ofStatus(response.data.status),
@@ -10086,7 +10064,7 @@ class WorkflowHandler {
                 }
             }
             catch (error) {
-                (0, debug_1.debug)('Workflow Run artifacts error', error);
+                (0, debug_1.debug)('Workflow Run status error', error);
                 throw error;
             }
         });

--- a/dist/index.js
+++ b/dist/index.js
@@ -10142,10 +10142,10 @@ class WorkflowHandler {
                 ref: this.ref,
                 filter: 'latest'
             });
-            if (result.length == 0) {
+            if (!result.data.check_runs.length) {
                 throw new Error('Run not found');
             }
-            return result.check_runs[0].id;
+            return result.data.check_runs[0].id;
         });
     }
     getWorkflowId() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -10136,7 +10136,7 @@ class WorkflowHandler {
     findWorklowRunIdFromRunName(runName) {
         return __awaiter(this, void 0, void 0, function* () {
             const workflowId = yield this.getWorkflowId();
-            const branch = (yield this.octokit.git.getRef({
+            const branch = (yield this.octokit.rest.git.getRef({
                 owner: this.owner,
                 repo: this.repo,
                 ref: this.ref,

--- a/dist/index.js
+++ b/dist/index.js
@@ -10136,16 +10136,10 @@ class WorkflowHandler {
     findWorklowRunIdFromRunName(runName) {
         return __awaiter(this, void 0, void 0, function* () {
             const workflowId = yield this.getWorkflowId();
-            const branch = (yield this.octokit.rest.git.getRef({
-                owner: this.owner,
-                repo: this.repo,
-                ref: this.ref,
-            })).replace('refs/heads/', '');
             const result = yield this.octokit.rest.actions.listWorkflowRuns({
                 owner: this.owner,
                 repo: this.repo,
                 workflow_id: workflowId,
-                branch,
                 event: 'workflow_dispatch',
                 created: `>=${new Date(this.triggerDate).toISOString()}`
             });

--- a/dist/index.js
+++ b/dist/index.js
@@ -10136,11 +10136,16 @@ class WorkflowHandler {
     findWorklowRunIdFromRunName(runName) {
         return __awaiter(this, void 0, void 0, function* () {
             const workflowId = yield this.getWorkflowId();
+            const branch = (yield this.octokit.git.getRef({
+                owner: this.owner,
+                repo: this.repo,
+                ref: this.ref,
+            })).replace('refs/heads/', '');
             const result = yield this.octokit.rest.actions.listWorkflowRuns({
                 owner: this.owner,
                 repo: this.repo,
                 workflow_id: workflowId,
-                branch: this.ref,
+                branch,
                 event: 'workflow_dispatch',
                 created: `>=${new Date(this.triggerDate).toISOString()}`
             });

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -172,17 +172,10 @@ export class WorkflowHandler {
   private async findWorklowRunIdFromRunName(runName: string): Promise<number> {
     const workflowId = await this.getWorkflowId();
 
-    const branch = (await this.octokit.rest.git.getRef({
-      owner: this.owner,
-      repo: this.repo,
-      ref: this.ref,
-    })).replace('refs/heads/', '');
-
     const result = await this.octokit.rest.actions.listWorkflowRuns({
       owner: this.owner,
       repo: this.repo,
       workflow_id: workflowId,
-      branch,
       event: 'workflow_dispatch',
       created: `>=${new Date(this.triggerDate).toISOString()}`
     });

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -172,11 +172,17 @@ export class WorkflowHandler {
   private async findWorklowRunIdFromRunName(runName: string): Promise<number> {
     const workflowId = await this.getWorkflowId();
 
+    const branch = (await this.octokit.git.getRef({
+      owner: this.owner,
+      repo: this.repo,
+      ref: this.ref,
+    })).replace('refs/heads/', '');
+
     const result = await this.octokit.rest.actions.listWorkflowRuns({
       owner: this.owner,
       repo: this.repo,
       workflow_id: workflowId,
-      branch: this.ref,
+      branch,
       event: 'workflow_dispatch',
       created: `>=${new Date(this.triggerDate).toISOString()}`
     });

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -180,11 +180,11 @@ export class WorkflowHandler {
       filter: 'latest'
     });
 
-    if (result.length == 0) {
+    if (!result.data.check_runs.length) {
       throw new Error('Run not found');
     }
 
-    return result.check_runs[0].id as number;
+    return result.data.check_runs[0].id as number;
   }
 
   private async getWorkflowId(): Promise<number | string> {

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -172,7 +172,7 @@ export class WorkflowHandler {
   private async findWorklowRunIdFromRunName(runName: string): Promise<number> {
     const workflowId = await this.getWorkflowId();
 
-    const branch = (await this.octokit.git.getRef({
+    const branch = (await this.octokit.rest.git.getRef({
       owner: this.owner,
       repo: this.repo,
       ref: this.ref,

--- a/src/workflow-handler.ts
+++ b/src/workflow-handler.ts
@@ -78,39 +78,16 @@ export class WorkflowHandler {
 
   async getWorkflowRunStatus(): Promise<WorkflowRunResult> {
     try {
-      const runId = await this.getWorkflowRunId();
-      const response = await this.octokit.rest.actions.getWorkflowRun({
-        owner: this.owner,
-        repo: this.repo,
-        run_id: runId
-      });
-      debug('Workflow Run status', response);
-
-      return {
-        url: response.data.html_url,
-        status: ofStatus(response.data.status),
-        conclusion: ofConclusion(response.data.conclusion)
-      };
-
-    } catch (error: any) {
-      debug('Workflow Run status error', error);
-      throw error;
-    }
-  }
-
-
-  async getWorkflowRunArtifacts(): Promise<WorkflowRunResult> {
-    try {
       if (this.runName) {
         return await this.findWorklowRunFromRunName(this.runName);
       } else {
         const runId = await this.getWorkflowRunId();
-        const response = await this.octokit.rest.actions.getWorkflowRunArtifacts({
+        const response = await this.octokit.rest.actions.getWorkflowRun({
           owner: this.owner,
           repo: this.repo,
           run_id: runId
         });
-        debug('Workflow Run artifacts', response);
+        debug('Workflow Run status', response);
 
         return {
           url: response.data.html_url,
@@ -119,12 +96,11 @@ export class WorkflowHandler {
         };
       }
 
-    } catch (error) {
-      debug('Workflow Run artifacts error', error);
+    } catch (error: any) {
+      debug('Workflow Run status error', error);
       throw error;
     }
   }
-
 
   async getWorkflowRunId(): Promise<number> {
     if (this.workflowRunId) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,7 +86,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -106,7 +106,7 @@
   dependencies:
     "@octokit/types" "^6.0.3"
 
-"@octokit/core@^3.6.0":
+"@octokit/core@^3.6.0", "@octokit/core@>=2", "@octokit/core@>=3":
   version "3.6.0"
   resolved "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz"
   integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==
@@ -211,7 +211,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@5.59.9":
+"@typescript-eslint/parser@^5.0.0", "@typescript-eslint/parser@5.59.9":
   version "5.59.9"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.9.tgz"
   integrity sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==
@@ -289,7 +289,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.8.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.8.0:
   version "8.8.2"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -447,7 +447,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz"
   integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
-eslint@8.42.0:
+eslint@*, "eslint@^6.0.0 || ^7.0.0 || ^8.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", eslint@8.42.0:
   version "8.42.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz"
   integrity sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==
@@ -520,7 +520,12 @@ estraverse@^4.1.1:
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
+estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -1005,7 +1010,7 @@ type-fest@^0.20.2:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-typescript@5.1.3:
+"typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta", typescript@5.1.3:
   version "5.1.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz"
   integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,7 +86,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -106,7 +106,7 @@
   dependencies:
     "@octokit/types" "^6.0.3"
 
-"@octokit/core@^3.6.0", "@octokit/core@>=2", "@octokit/core@>=3":
+"@octokit/core@^3.6.0":
   version "3.6.0"
   resolved "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz"
   integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==
@@ -211,7 +211,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.0.0", "@typescript-eslint/parser@5.59.9":
+"@typescript-eslint/parser@5.59.9":
   version "5.59.9"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.9.tgz"
   integrity sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==
@@ -289,7 +289,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.8.0:
+acorn@^8.8.0:
   version "8.8.2"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -447,7 +447,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz"
   integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
-eslint@*, "eslint@^6.0.0 || ^7.0.0 || ^8.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", eslint@8.42.0:
+eslint@8.42.0:
   version "8.42.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz"
   integrity sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==
@@ -520,12 +520,7 @@ estraverse@^4.1.1:
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0:
-  version "5.3.0"
-  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
-  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
-
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -1010,7 +1005,7 @@ type-fest@^0.20.2:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-"typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta", typescript@5.1.3:
+typescript@5.1.3:
   version "5.1.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz"
   integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==


### PR DESCRIPTION
When providing a `run-name`, the following error occurs: `Failed to get workflow url: Cannot read properties of undefined (reading '0')`. The root cause is that `check_runs` exists on the `result.data` object and not directly on the `result` variable (in `findWorklowRunIdFromRunName`). Initially, this PR was to fix the error condition and return value of this method. However, after further debugging, it was found that the returned `job id` was being incorrectly applied to the `octokit.rest.actions.getWorkflowRun` call in the `getWorkflowRunStatus` method (which is expecting a `run id`).

Additional updates were needed to return the full `WorkflowRunResult` of the `check_run` and have it correctly filtered for runs invoked after `this.triggerDate` (logic borrowed from `findWorkflowRunIdFromFirstRunOfSameWorkflowId`). Overall, conditions and return values for 3 class methods in `WorkflowHandler` were updated and 1 unused method was removed (`getWorkflowRunArtifacts`). The functionality of providing a `run-name` in the action config should now work as expected.